### PR TITLE
fix(index): replace this.requestAnimationFrame

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -260,7 +260,7 @@ class ScrollableTabView extends Component {
     const {width} = e.nativeEvent.layout
     if (Math.round(width) !== Math.round(this.state.containerWidth)) {
       this.setState({containerWidth: width})
-      this.requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
         this.goToPage(this.state.currentPage)
       })
     }


### PR DESCRIPTION
My app was crashing on screen orientation change, due to ```this.requestAnimationFrame```
So I replaced this.requestAnimationFrame with request animation frame as **requestAnimationFrame** is globally available in react native.

requestAnimationFrame is a polyfill from the browser, in the browser as well it is scoped to the window object.
See here:
https://stackoverflow.com/questions/51258292/use-requestanimationframe-in-react-native